### PR TITLE
Notify listeners when updating values automatically

### DIFF
--- a/Sources/Statsig/NetworkService.swift
+++ b/Sources/Statsig/NetworkService.swift
@@ -30,9 +30,9 @@ class NetworkService {
         for user: StatsigUser,
         lastSyncTimeForUser: UInt64,
         previousDerivedFields: [String: String],
-        completion: (() -> Void)?
+        completion: completionBlock
     ) {
-        let (body, _) = makeReqBody([
+        let (body, parseErr) = makeReqBody([
             "user": user.toDictionary(forLogging: false),
             "statsigMetadata": user.deviceEnvironment,
             "lastSyncTimeForUser": lastSyncTimeForUser,
@@ -41,21 +41,40 @@ class NetworkService {
 
         guard let body = body else {
             self.store.finalizeValues()
-            completion?()
+            completion?(parseErr?.localizedDescription)
             return
         }
 
         let cacheKey = UserCacheKey.from(user: user, sdkKey: self.sdkKey)
         let fullUserHash = user.getFullUserHash()
 
-        makeAndSendRequest(.initialize, body: body) { [weak self] data, _, _ in
-            guard let dict = data?.json, dict["has_updates"] as? Bool == true else {
-                self?.store.finalizeValues()
-                completion?()
+        makeAndSendRequest(.initialize, body: body) { [weak self] data, response, error in
+            if let error {
+                completion?(error.localizedDescription)
+                return
+            }
+            
+            let statusCode = response?.status ?? 0
+
+            if !(200...299).contains(statusCode) {
+                completion?("An error occurred during fetching updated values for the user. \(statusCode)")
                 return
             }
 
-            self?.store.saveValues(dict, cacheKey, fullUserHash, completion)
+            guard let self = self else {
+                completion?("Failed to call NetworkService as it has been released")
+                return
+            }
+            
+            guard let dict = data?.json, dict["has_updates"] as? Bool == true else {
+                self.store.finalizeValues()
+                completion?("No updates when fetching updated values for user")
+                return
+            }
+
+            self.store.saveValues(dict, cacheKey, fullUserHash) {
+                completion?(nil)
+            }
         }
     }
 

--- a/Sources/Statsig/StatsigClient.swift
+++ b/Sources/Statsig/StatsigClient.swift
@@ -704,9 +704,9 @@ extension StatsigClient {
         self.networkService.fetchUpdatedValues(
             for: currentUser,
             lastSyncTimeForUser: sinceTime,
-            previousDerivedFields: previousDerivedFields,
-            completion: nil
-        )
+            previousDerivedFields: previousDerivedFields) { [weak self] error in
+                self?.notifyOnUserUpdatedListeners(error)
+            }
     }
 
     private static func normalizeUser(_ user: StatsigUser?, options: StatsigOptions?) -> StatsigUser {

--- a/Tests/StatsigTests/NetworkServiceSpec.swift
+++ b/Tests/StatsigTests/NetworkServiceSpec.swift
@@ -76,7 +76,7 @@ class NetworkServiceSpec: BaseSpec {
                         for: StatsigUser(userID: "jkw"),
                         lastSyncTimeForUser: now,
                         previousDerivedFields: [:]
-                    ) {
+                    ) { _ in
                         done()
                     }
                 }


### PR DESCRIPTION
This PR enables listeners to receive notifications when values have been updated. Fixes issue #14 .

It's not entirely clear if the lack of notifications in this case is by design or an oversight when `enableAutoValueUpdate` was added, but I'm assuming the latter.