### PR TITLE
Expose method for getting feature gate details from static API

### DIFF
--- a/Sources/Statsig/Statsig.swift
+++ b/Sources/Statsig/Statsig.swift
@@ -114,6 +114,18 @@ public class Statsig {
     }
 
     /**
+     Get the value for the given feature gate.
+
+     Parameters:
+     - gateName: The name of the feature gate setup on console.statsig.com
+
+     SeeAlso [Gate Documentation](https://docs.statsig.com/feature-gates/working-with)
+     */
+    public static func getFeatureGate(_ gateName: String) -> FeatureGate {
+        return checkGateImpl(gateName, withExposures: true, functionName: funcName())
+    }
+
+    /**
      Get the value for the given feature gate. No exposure event will be logged.
 
      Parameters:


### PR DESCRIPTION
The static `Statsig` API currently exposes a `getFeatureGateWithExposureLoggingDisabled` method but lacks a corresponding `getFeatureGate` method, despite the latter being exposed on instances of `StatsigClient`. This PR addresses that gap in functionality by adding a new `static Statsig.getFeatureGate(_:)` method.