### PR TITLE
Add support for overriding param stores

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.swift]
+indent_style = space
+indent_size = 4

--- a/Sources/Statsig/Statsig.swift
+++ b/Sources/Statsig/Statsig.swift
@@ -468,6 +468,17 @@ public class Statsig {
     }
 
     /**
+     Sets a value to be returned for the given parameter store instead of following the actual ref in the store.
+
+     Parameters:
+     - storeName: The name of the config or experiment to be overridden
+     - value: Dictionary where keys are property names and values are static ref values in the overridden store
+     */
+    public static func overrideParamStore(_ storeName: String, value: [String: Any]) {
+        client?.overrideParamStore(storeName, value: value)
+    }
+
+    /**
      Clears any overridden value for the given gate/dynamic config/experiment.
 
      Parameters:

--- a/Sources/Statsig/StatsigClient.swift
+++ b/Sources/Statsig/StatsigClient.swift
@@ -674,6 +674,17 @@ extension StatsigClient {
     }
 
     /**
+     Sets a value to be returned for the given parameter store instead of following the actual ref in the store.
+
+     Parameters:
+     - storeName: The name of the config or experiment to be overridden
+     - value: Dictionary where keys are property names and values are static ref values in the overridden store
+     */
+    public func overrideParamStore(_ storeName: String, value: [String: Any]) {
+        store.overrideParamStore(storeName, value)
+    }
+
+    /**
      Clears any overridden value for the given gate/dynamic config/experiment.
 
      Parameters:

--- a/Tests/StatsigTests/LocalOverridesSpec.swift
+++ b/Tests/StatsigTests/LocalOverridesSpec.swift
@@ -74,6 +74,20 @@ class LocalOverridesSpec: BaseSpec {
                 }
             }
 
+            describe("parameter store overrides")  {
+                it("returns overridden parameter store values") {
+                    Statsig.overrideParamStore("overridden_param_store", value: ["key": "value"])
+                    let store = Statsig.getParameterStore("overridden_param_store")
+                    expect(store.getValue(forKey: "key", defaultValue: "default")).to(equal("value"))
+                }
+
+                it("clears overridden parameter store values") {
+                    Statsig.overrideParamStore("overridden_param_store", value: ["key": "value"])
+                    Statsig.removeOverride("overridden_param_store")
+                    expect(Statsig.getParameterStore("overridden_param_store").getValue(forKey: "key", defaultValue: "default")).to(equal("default"))
+                }
+            }
+
             describe("clearing all overrides") {
                 it("clears all") {
                     Statsig.overrideGate("overridden_gate", value: true)


### PR DESCRIPTION
Even if setting overrides for the underlying refs worked (which it doesn't seem to) the whole point of parameter stores is that the client isn't supposed to have to know where the value actually comes from.

This adds support for overriding a parameter store. It does this by creating a param store for the override with exclusively static refs.