### PR TITLE
Make initialization consistently synchronous when passing a storageProvider

### DIFF
--- a/Sources/Statsig/Statsig.swift
+++ b/Sources/Statsig/Statsig.swift
@@ -43,10 +43,8 @@ public class Statsig {
                 _initialize()
             }
         } else if let storageProvider = options?.storageProvider {
-            DispatchQueue.main.async {
-                StatsigUserDefaults.defaults = StorageProviderBasedUserDefaults(storageProvider: storageProvider)
-                _initialize()
-            }
+            StatsigUserDefaults.defaults = StorageProviderBasedUserDefaults(storageProvider: storageProvider)
+            _initialize()
         } else {
             _initialize()
         }


### PR DESCRIPTION
Follow-up to https://github.com/statsig-io/ios-sdk/commit/c7fd74289f5d5b7810d6f428355b0597a264d199