### PR TITLE
Expose param_stores in Initialize Response JSON

### DIFF
--- a/Sources/Statsig/StatsigClient.swift
+++ b/Sources/Statsig/StatsigClient.swift
@@ -190,6 +190,7 @@ public class StatsigClient {
             "feature_gates": self.store.cache.gates,
             "dynamic_configs": self.store.cache.configs,
             "layer_configs": self.store.cache.layers,
+            "param_stores": self.store.cache.paramStores,
             "hash_used": self.store.cache.hashUsed,
             "time": self.store.cache.userCache["time"]
         ]


### PR DESCRIPTION
The Android SDK directly [exposes its cache](https://github.com/statsig-io/android-sdk/blob/f4df281d983598bc3213e7e345831cdd72a732ac/src/main/java/com/statsig/androidsdk/Store.kt#L461) via its StatsigClient method [`getInitializeResponseJson()`](https://github.com/statsig-io/android-sdk/blob/f4df281d983598bc3213e7e345831cdd72a732ac/src/main/java/com/statsig/androidsdk/StatsigClient.kt#L632), however the iOS StatsigClient only exposes a subset of properties from the original JSON response. Most notably, the `param_stores` are missing. This PR exposes that data.