### PR TITLE
[codex] Pin GitHub Actions workflow references

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           - platform_type: visionos
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # main
 
       - name: Prepare Simulator
         id: simulator

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # main
 
       - name: Set Up Swift
-        uses: swift-actions/setup-swift@v2
+        uses: swift-actions/setup-swift@7591e4f04c00624cb043783da51a7fd6ee0a6bf6 # v2
         with:
           swift-version: "6.2"
 

--- a/.github/workflows/pod-lint.yml
+++ b/.github/workflows/pod-lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # main
 
       - name: Lint Podspec
         run: pod lib lint Statsig.podspec --skip-tests

--- a/.github/workflows/publish-to-cocoapods.yml
+++ b/.github/workflows/publish-to-cocoapods.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Publish to CocoaPods
         env:

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -12,6 +12,6 @@ jobs:
     if: startsWith(github.head_ref, 'releases/') || github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
-      - uses: statsig-io/statsig-publish-sdk-action@main
+      - uses: statsig-io/statsig-publish-sdk-action@c0740fb8a2d4813522cc09bb8c4e826bb78ce6ab # main
         with:
           kong-private-key: ${{ secrets.KONG_GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Trigger Scheduled Test Runs
         if: github.event.repository.private
-        uses: actions/github-script@v6
+        uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # v6
         with:
           script: |
             const args = {

--- a/.github/workflows/test-pod-install.yml
+++ b/.github/workflows/test-pod-install.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Cache CocoaPods specs
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ~/.cocoapods
           key: ${{ runner.os }}-cocoapods-specs-${{ hashFiles('**/Podfile') }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # main
 
       - name: Prepare Simulator
         id: simulator


### PR DESCRIPTION
Pin floating external GitHub Actions workflow refs to immutable SHAs.

Why are we doing this? Please see the rationale doc: https://docs.google.com/document/d/1qOURCNx2zszQ0uWx7Fj5ERu4jpiYjxLVWBWgKa2wTsA/edit?tab=t.0

Did this break you? Please roll back and let hintz@ know
