### PR TITLE
Redact sensitive diagnostics option values

### DIFF
--- a/Sources/Statsig/StatsigOptions.swift
+++ b/Sources/Statsig/StatsigOptions.swift
@@ -381,23 +381,23 @@ extension StatsigOptions {
         if urlSession != URLSession.shared {
             dict["urlSession"] = "set"
         }
-        if let id = overrideStableID, id != defaultOptions.overrideStableID {
-            dict["overrideStableID"] = id.count < 50 ? id : "set"
+        if overrideStableID != defaultOptions.overrideStableID {
+            dict["overrideStableID"] = "set"
         }
         if let initURL = initializationURL,
             initURL.absoluteString != defaultOptions.initializationURL?.absoluteString
         {
-            dict["initializationURL"] = initURL.absoluteString
+            dict["initializationURL"] = initURL.loggingSafeAbsoluteString
         }
         if let logURL = eventLoggingURL,
             logURL.absoluteString != defaultOptions.eventLoggingURL?.absoluteString
         {
-            dict["eventLoggingURL"] = logURL.absoluteString
+            dict["eventLoggingURL"] = logURL.loggingSafeAbsoluteString
         }
         if let exceptionURL = sdkExceptionDiagnosticsURL,
             exceptionURL.absoluteString != defaultOptions.sdkExceptionDiagnosticsURL?.absoluteString
         {
-            dict["sdkExceptionDiagnosticsURL"] = exceptionURL.absoluteString
+            dict["sdkExceptionDiagnosticsURL"] = exceptionURL.loggingSafeAbsoluteString
         }
         if initTimeout != defaultOptions.initTimeout {
             dict["initTimeout"] = initTimeout
@@ -462,5 +462,16 @@ extension URL {
         urlComponents.host = host
         urlComponents.port = port
         return urlComponents.url
+    }
+
+    var loggingSafeAbsoluteString: String {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            return absoluteString
+        }
+        components.user = nil
+        components.password = nil
+        components.query = nil
+        components.fragment = nil
+        return components.url?.absoluteString ?? absoluteString
     }
 }

--- a/Tests/StatsigTests/StatsigOptionsSpec.swift
+++ b/Tests/StatsigTests/StatsigOptionsSpec.swift
@@ -125,6 +125,26 @@ class StatsigOptionsSpec: BaseSpec {
                     expect(dict["overrideAdapter"] as? String).to(equal("set"))
                 }
 
+                it("redacts stable IDs from logging") {
+                    let opts = StatsigOptions(overrideStableID: "user@example.com")
+                    let dict = opts.getDictionaryForLogging()
+                    expect(dict["overrideStableID"] as? String).to(equal("set"))
+                }
+
+                it("removes credentials query and fragment from logged URLs") {
+                    let opts = StatsigOptions(
+                        initializationURL: URL(string: "https://user:pass@example.com/v1/initialize?token=secret#frag"),
+                        eventLoggingURL: URL(string: "https://user:pass@example.com/v1/rgstr?token=secret#frag"),
+                        sdkExceptionDiagnosticsURL: URL(string: "https://user:pass@example.com/v1/sdk_exception?token=secret#frag")
+                    )
+
+                    let dict = opts.getDictionaryForLogging()
+
+                    expect(dict["initializationURL"] as? String).to(equal("https://example.com/v1/initialize"))
+                    expect(dict["eventLoggingURL"] as? String).to(equal("https://example.com/v1/rgstr"))
+                    expect(dict["sdkExceptionDiagnosticsURL"] as? String).to(equal("https://example.com/v1/sdk_exception"))
+                }
+
                 it("creates a dictionary with every option") {
                     let ignoredKeys = [
                         "getDictionaryForLogging",


### PR DESCRIPTION
## Summary
- avoid sending the literal overrideStableID value in diagnostics logging
- remove URL credentials, query strings, and fragments before including custom endpoint URLs in diagnostics payloads
- add tests for stable ID and URL redaction in getDictionaryForLogging()

## Validation
- Not run locally: Swift toolchain is not installed on this Windows machine.
- Local checkout note: source was inspected from a tar archive because this workspace is Windows-based.